### PR TITLE
chore: update version to 15.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-webapp-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Webapp Plugin</name>
-	<version>15.1.0-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-webapp-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-webapp-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

This PR updates the project version from 15.1.0-SNAPSHOT to 15.3.0-SNAPSHOT to align with the latest Fess release cycle. The parent POM dependency has also been updated to version 15.3.0.

## Changes Made

- Updated project version in pom.xml from `15.1.0-SNAPSHOT` to `15.3.0-SNAPSHOT`
- Updated fess-parent dependency from version `15.1.0` to `15.3.0`

## Testing

- Build verification required after merge
- No functional changes, version bump only
- Maven dependency resolution should be tested

## Breaking Changes

None. This is a version increment that maintains backward compatibility.

## Additional Notes

This version update prepares the plugin for compatibility with Fess 15.3.0. Reviewers should verify that the fess-parent 15.3.0 dependency is available in the Maven repository before merging.